### PR TITLE
Use streams

### DIFF
--- a/src/main/java/yappy/ui/CommandInfos.java
+++ b/src/main/java/yappy/ui/CommandInfos.java
@@ -1,5 +1,7 @@
 package yappy.ui;
 
+import java.util.List;
+import java.util.stream.Collectors;
 import yappy.task.TaskType;
 import yappy.util.DateTimeUtil;
 
@@ -42,10 +44,9 @@ public class CommandInfos {
 
 
     private static String generateDateTimeUsage() {
-        String s = "\n\nFor datetime, please use one of the following supported formats:\n";
-        for (String usage : DateTimeUtil.getUsageForSupportedFormats()) {
-            s += " - " + usage + "\n";
-        }
+        List<String> usages = DateTimeUtil.getUsageForSupportedFormats();
+        String s = "\n\nFor datetime, please use one of the following supported formats:\n"
+                + usages.stream().map(u -> " - " + u).collect(Collectors.joining("\n"));
         return s;
     }
 }


### PR DESCRIPTION
Currently, the help message for date time usage, leaves a newline at the end of its message.

This causes the gui to not render the message nicely.

Fix the newline addition at the end. At the same time, get to use java streams (even though other part of the codebase already previously use streams).

This makes the gui render the message more nicely.